### PR TITLE
Brought back support for Python 2.6 (regarding issue #1)

### DIFF
--- a/pyhdb/__init__.py
+++ b/pyhdb/__init__.py
@@ -81,7 +81,7 @@ def from_ini(ini_file, section=None):
         return param[5:] if param.startswith('hana_') else param
 
     valid_keys = ('host', 'port', 'user', 'password')
-    clean_params = {'%s' % rm_prefix(key): val for key, val in params.items() if rm_prefix(key) in valid_keys}
+    clean_params = dict([('%s' % rm_prefix(key), val) for key, val in params.items() if rm_prefix(key) in valid_keys])
 
     # make actual connection:
     return connect(**clean_params)

--- a/pyhdb/compat.py
+++ b/pyhdb/compat.py
@@ -27,6 +27,8 @@ if PY2:
     iter_range = xrange
     import ConfigParser as configparser
     from itertools import izip
+    import StringIO as _StringIO
+    StringIO = _StringIO.StringIO
 else:
     text_type = str
     byte_type = bytes
@@ -36,6 +38,8 @@ else:
     iter_range = range
     import configparser
     izip = zip
+    import io
+    StringIO = io.StringIO
 
 # workaround for 'narrow' Python builds
 if sys.maxunicode <= 65535:

--- a/pyhdb/lib/tracing.py
+++ b/pyhdb/lib/tracing.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 import io
 import pyhdb
+from pyhdb.compat import StringIO
 
 
 def trace(trace_obj):
@@ -34,7 +35,7 @@ class TraceLogger(object):
     def __init__(self):
         self._indent_level = 0
         self._indent_level_is_first = {0: True}
-        self._buffer = io.StringIO()
+        self._buffer = StringIO()
 
     def trace(self, trace_obj):
         """
@@ -45,13 +46,13 @@ class TraceLogger(object):
         tracer = self
         tracer.writeln(u'%s = ' % trace_obj.__class__.__name__)
         tracer.incr('{')
-        for attr_name in trace_obj.__tracing_attrs__:
+        for attr_name in sorted(trace_obj.__tracing_attrs__):
             attr = getattr(trace_obj, attr_name)
             if isinstance(attr, tuple) and hasattr(attr, '_fields'):
                 # probably a namedtuple instance
                 tracer.writeln(u'%s = ' % (attr_name,))
                 tracer.incr('[')
-                for k, v in attr._asdict().items():
+                for k, v in sorted(attr._asdict().items()):
                     # _asdict() creates an OrderedDict, so elements are still in order
                     tracer.writeln(u'%s = %s' % (k, v))
                 tracer.decr(']')

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -14,18 +14,20 @@
 
 import io
 import logging
+from os import SEEK_SET, SEEK_CUR, SEEK_END
+
 from pyhdb.protocol.headers import ReadLobHeader
 from pyhdb.protocol.message import RequestMessage
 from pyhdb.protocol.segments import RequestSegment
 from pyhdb.protocol.constants import message_types, type_codes
 from pyhdb.protocol.parts import ReadLobRequest
-from pyhdb.compat import PY2, PY3, byte_type
+from pyhdb.compat import PY2, PY26, PY3, byte_type, StringIO
 
 if PY2:
     # Depending on the Python version we use different underlying containers for CLOB strings
-    import StringIO
+    import StringIO as _StringIO
     import cStringIO
-    CLOB_STRING_IO_CLASSES = (StringIO.StringIO, cStringIO.InputType, cStringIO.OutputType)
+    CLOB_STRING_IO_CLASSES = (_StringIO.StringIO, cStringIO.InputType, cStringIO.OutputType)
 
     def CLOB_STRING_IO(init_value):
         # factory function to obtain a read-writable StringIO object
@@ -40,10 +42,6 @@ else:
 
 
 logger = logging.getLogger('pyhdb')
-
-SEEK_SET = io.SEEK_SET
-SEEK_CUR = io.SEEK_CUR
-SEEK_END = io.SEEK_END
 
 
 def from_payload(type_code, payload, connection):
@@ -264,7 +262,7 @@ class NClob(_CharLob):
         return self.data.getvalue()
 
     def _init_io_container(self, init_value):
-        if isinstance(init_value, io.StringIO):
+        if isinstance(init_value, type(StringIO())):
             return init_value
 
         if PY2 and isinstance(init_value, str):
@@ -273,7 +271,7 @@ class NClob(_CharLob):
         if PY3 and isinstance(init_value, byte_type):
             init_value = init_value.decode(self.encoding)
 
-        return io.StringIO(init_value)
+        return StringIO(init_value)
 
 
 LOB_TYPE_CODE_MAP = {

--- a/pyhdb/protocol/message.py
+++ b/pyhdb/protocol/message.py
@@ -14,6 +14,7 @@
 
 import io
 import struct
+from os import SEEK_SET, SEEK_CUR, SEEK_END
 ###
 from pyhdb.protocol import constants
 from pyhdb.protocol.headers import MessageHeader
@@ -49,7 +50,7 @@ class RequestMessage(BaseMessage):
         payload = io.BytesIO()
         # Advance num bytes equal to header size - the header is written later
         # after the payload of all segments and parts has been written:
-        payload.seek(self.header_size, io.SEEK_CUR)
+        payload.seek(self.header_size, SEEK_CUR)
 
         # Write out payload of segments and parts:
         self.build_payload(payload)
@@ -62,7 +63,7 @@ class RequestMessage(BaseMessage):
         # Go back to begining of payload for writing message header:
         payload.seek(0)
         payload.write(packed_header)
-        payload.seek(0, io.SEEK_END)
+        payload.seek(0, SEEK_END)
 
         trace(self)
 

--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -21,6 +21,7 @@ import struct
 import logging
 from collections import namedtuple
 from weakref import WeakValueDictionary
+from os import SEEK_SET, SEEK_CUR, SEEK_END
 ###
 import pyhdb
 from pyhdb.lib.stringlib import humanhexlify
@@ -569,7 +570,7 @@ class Parameters(Part):
             payload.write(lob_buffer.DataType.prepare(None, length=max_data_to_write,
                                                       position=rel_lob_pos, is_last_data=is_last_data))
             # Set pointer back to end for further writing
-            payload.seek(0, io.SEEK_END)
+            payload.seek(0, SEEK_END)
         return unwritten_lobs
 
 

--- a/pyhdb/protocol/segments.py
+++ b/pyhdb/protocol/segments.py
@@ -16,6 +16,7 @@ import io
 import struct
 import logging
 from io import BytesIO
+from os import SEEK_SET, SEEK_CUR, SEEK_END
 ###
 from pyhdb.protocol.constants import part_kinds
 from pyhdb.compat import iter_range
@@ -88,7 +89,7 @@ class RequestSegment(BaseSegment):
 
         # Advance num bytes equal to header size. The header is written later
         # after the payload of all segments and parts has been written:
-        payload.seek(self.header_size, io.SEEK_CUR)
+        payload.seek(self.header_size, SEEK_CUR)
 
         # Generate payload of parts:
         self.build_payload(payload)
@@ -102,7 +103,7 @@ class RequestSegment(BaseSegment):
         payload.seek(segment_payload_start_pos)
         payload.write(packed_header)
         # Put file pointer at the end of the bffer so that next segment can be appended:
-        payload.seek(0, io.SEEK_END)
+        payload.seek(0, SEEK_END)
 
 
 class ReplySegment(BaseSegment):

--- a/tests/lib/test_tracing.py
+++ b/tests/lib/test_tracing.py
@@ -22,12 +22,12 @@ from pyhdb.lib.tracing import trace
 
 TRACE_MSG = '''RequestMessage = {
     header = [
-        session_id = 5,
-        packet_count = 3,
-        payload_length = 500,
-        varpartsize = 500,
         num_segments = 1,
-        packet_options = 0
+        packet_count = 3,
+        packet_options = 0,
+        payload_length = 500,
+        session_id = 5,
+        varpartsize = 500
     ],
     segments = [
         RequestSegment = {
@@ -35,9 +35,9 @@ TRACE_MSG = '''RequestMessage = {
             parts = [
                 Command = {
                     header = None,
+                    sql_statement = 'select * from dummy',
                     trace_header = '',
-                    trace_payload = '',
-                    sql_statement = 'select * from dummy'
+                    trace_payload = ''
                 }
             ]
         }

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -163,7 +163,7 @@ def test_cursor_execute_with_params5(connection, test_table_1, content_table_1):
     # Note: use fetchall() to check that only one row gets returned
     cursor = connection.cursor()
 
-    sql = 'select test from {} where test=%(test)s'.format(TABLE)
+    sql = 'select test from {0} where test=%(test)s'.format(TABLE)
     # correct way:
     assert cursor.execute(sql, {'test': 'row2'}).fetchall() == [('row2',)]
     # also correct way, additional dict value should just be ignored
@@ -251,7 +251,7 @@ def test_cursor_executemany_python_expansion(connection, test_table_1):
     cursor = connection.cursor()
 
     cursor.executemany(
-        "INSERT INTO {} VALUES(%s)".format(TABLE),
+        "INSERT INTO {0} VALUES(%s)".format(TABLE),
         (
             ("Statement 1",),
             ("Statement 2",)

--- a/tests/types/test_lob.py
+++ b/tests/types/test_lob.py
@@ -24,7 +24,7 @@ import mock
 
 from pyhdb.protocol import lobs
 from pyhdb.protocol.types import type_codes
-from pyhdb.compat import PY2, PY3, iter_range, text_type
+from pyhdb.compat import PY2, PY3, iter_range, text_type, StringIO
 from pyhdb.protocol import constants
 
 # #############################################################################################################
@@ -133,7 +133,7 @@ def test_clob___unicode___method():
 def test_nclob_uses_string_io():
     data = string.ascii_letters
     nclob = lobs.NClob(data)
-    assert isinstance(nclob.data, io.StringIO)
+    assert isinstance(nclob.data, StringIO)
 
 
 def test_nclob_from_ascii_string():
@@ -160,7 +160,7 @@ def test_nclob_from_unicode():
 
 def test_nclob_from_string_io():
     data = u'朱の子ましけ'
-    text_io = io.StringIO(data)
+    text_io = StringIO(data)
     nclob = lobs.NClob(text_io)
     assert nclob.getvalue() == data
     assert nclob.data is text_io
@@ -296,6 +296,7 @@ def test_lob_init_and_more(type_code, lob_header, bin_lob_data, lob_data, lob_da
     assert len(lob) == len(lob_data)
     assert lob.read() == lob_data
     assert lob.tell() == len(lob_data)
+
     assert lob.read(5) == lob_data_empty
     # go back to begging of lob, and just read three chars:
     assert lob.seek(0) == 0


### PR DESCRIPTION
- LOB functionalities use `StringIO.StringIO` in Python 2.x and `io.StringIO` in Python 3.x
- `SEEK_*` macros from `os` module are used in every Python version
