### PR TITLE
make sure the msg is bytes

### DIFF
--- a/pyhdb/auth.py
+++ b/pyhdb/auth.py
@@ -84,7 +84,7 @@ class AuthManager(object):
         key_hash = hashlib.sha256(key).digest()
 
         sig = hmac.new(
-            key_hash, msg, hashlib.sha256
+            key_hash, str(msg), hashlib.sha256
         ).digest()
 
         return self._xor(sig, key)


### PR DESCRIPTION
The user may pass the non-bytes variable to the AuthManager, thus the msg=salt+server_key+self.client_key may not be bytes, which causes an error on python2.6.
